### PR TITLE
Parse SOA and MX records regardless of case

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ DNS Zone File
 
 from setuptools import setup, find_packages
 
-version = "0.1.5"
+version = "0.1.6"
 
 setup(
     name='zonefile_parser',

--- a/zonefile_parser/helper.py
+++ b/zonefile_parser/helper.py
@@ -75,7 +75,7 @@ def find_soa_lines(text:str):
 
     for line_number in range(0,len(lines)-1):
         line = lines[line_number]
-        if "SOA" in line:
+        if "SOA" in line.upper():
             soa_start_line = line_number
             if "(" in line:
                 find_bracket = True

--- a/zonefile_parser/parser.py
+++ b/zonefile_parser/parser.py
@@ -22,21 +22,21 @@ def parse_record(parts:list) -> Record:
 
     record.set_name(parts[RecordEnum.NAME])
     record.set_ttl(parts[RecordEnum.TTL])
-    record.set_rclass(parts[RecordEnum.RCLASS])
-    record.set_rtype(parts[RecordEnum.RTYPE])
+    record.set_rclass(parts[RecordEnum.RCLASS].upper())
+    record.set_rtype(parts[RecordEnum.RTYPE].upper())
 
     # rdata is unique for MX and SOA, everything else is the same.
-    if parts[RecordEnum.RTYPE] not in ["MX","SOA"]:
+    if record.rtype not in ["MX","SOA"]:
         record.set_rdata({
             "value":parts[RecordEnum.RDATA]
         })
-    elif parts[RecordEnum.RTYPE] == "MX":
+    elif record.rtype == "MX":
         # the record is a SOA or MX
         record.set_rdata({
             "priority": parts[RecordEnum.MX_PRIORITY],
             "host":parts[RecordEnum.MX_HOST]
         })
-    elif parts[RecordEnum.RTYPE] == "SOA":
+    elif record.rtype == "SOA":
         record.set_rdata({
                 "mname": parts[RecordEnum.SOA_MNAME],
                 "rname": parts[RecordEnum.SOA_RNAME],


### PR DESCRIPTION
The library assumes that all zone files will have `SOA` and `MX` but this isn't always the case. In zone files with `soa` or `mx` these records are not correctly parsed and expected fields are missing from `rdata`.

Input:
```
name.   86400   in      soa     ac1.nstld.com. info.verisign-grs.com. 1606312771 1800 900 604800 86400
```

Behaviour before change:
```
import zonefile_parser
with open("name.zone", "r") as infile:
  records = zonefile_parser.parse(infile.read())
for record in records:
  if record.rtype == "soa":
    print(record)
    break
{'rtype': 'soa', 'name': 'name.', 'rclass': 'in', 'rdata': {'value': 'ac1.nstld.com.'}, 'ttl': '86400'}
```

Behaviour after change:
```
import zonefile_parser
with open("name.zone", "r") as infile:
  records = zonefile_parser.parse(infile.read())
for record in records:
  if record.rtype == "SOA":
    print(record)
    break
{'rtype': 'SOA', 'name': 'name.', 'rclass': 'IN', 'rdata': {'mname': 'ac1.nstld.com.', 'rname': 'info.verisign-grs.com.', 'serial': '1606312771', 'refresh': '1800', 'retry': '900', 'expire': '604800', 'minimum': '86400'}, 'ttl': '86400'}
```