### PR TITLE
Fixed incorrect parsing if rclass is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ DNS Zone File
 from setuptools import setup, find_packages
 
 
-version = "0.1.8"
+version = "0.1.9"
 
 
 setup(

--- a/zonefile_parser/main.py
+++ b/zonefile_parser/main.py
@@ -91,19 +91,15 @@ def parse(text:str):
 
     # add a TTL to records where one doesn't exist
     def add_ttl(record:list):
-        if record[1] == "IN":
+        if not record[1].isdigit():
             record.insert(1,ttl)
 
         return record
 
     # add an rclass (defaults to IN) when one isn't present
     def add_rclass(record:list):
-        # there are at least 5 required fields for each record
-        if len(record) < 5 and record[1].isdigit():
+        if not (record[2] in ('IN','CS','CH','HS')):
             record.insert(2,default_rclass)
-
-        if len(record) < 5 and record[2].isdigit():
-            record.insert(1,default_rclass)
 
         return record
 


### PR DESCRIPTION
Records are not parsed correctly, when rclass is missing. 

**Changes:**
* Check if `record[1]` is not numeric -> TTL is missing, add it
* Check if `record[2]` is no valid rclass -> add default rclass 'IN'
  -> length-Check does not work, e.g.  `test    3600                MX      10      test.mail.com. `  -> `len(record)==5`, no rclass added
  -> Position check is not required, as record is normalized. (TTL is already contained in record, so record[2] must contain rclass)