### PR TITLE
Support lower case rtype lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 zone_file_parser.egg-info
 dist
 zonefile_parser.egg-info
+.coverage

--- a/zonefile_parser/main.py
+++ b/zonefile_parser/main.py
@@ -98,7 +98,7 @@ def parse(text:str):
 
     # add an rclass (defaults to IN) when one isn't present
     def add_rclass(record:list):
-        if not (record[2] in ('IN','CS','CH','HS')):
+        if not (str(record[2]).upper() in ('IN','CS','CH','HS')):
             record.insert(2,default_rclass)
 
         return record

--- a/zonefile_parser/main_test.py
+++ b/zonefile_parser/main_test.py
@@ -24,6 +24,29 @@ _sip._tcp.example.com. 86400 IN SRV 0 5 5060 sipserver.example.com.
             "host":"sipserver.example.com."
         })
 
+    def test_handles_lowercase_rclass(self):
+        text = """
+$TTL 10d
+$ORIGIN example.com.
+@ 86400 IN CAA 0 issue "ca.example.com"
+""" 
+        result = zonefile_parser.main.parse(text)
+
+        record = result[0]
+
+        assert record.rclass == "IN"
+    def test_handles_mixedcase_rclass(self):
+        text = """
+$TTL 10d
+$ORIGIN example.com.
+@ 86400 iN CAA 0 issue "ca.example.com"
+""" 
+        result = zonefile_parser.main.parse(text)
+
+        record = result[0]
+
+        assert record.rclass == "IN"
+
     def test_correctly_parses_caa(self):
         text = """
 $TTL 10d


### PR DESCRIPTION
A zone file could contains upper or lower case rtype values. To
support both formats it's required to unify them for an lookup.