### PR TITLE
Fix parsing bind plain file

### DIFF
--- a/zonefile_parser/helper.py
+++ b/zonefile_parser/helper.py
@@ -87,13 +87,12 @@ def default_origin(text:str):
     return None
 
 
-
 # ensure that the string:
 # 1. ends and starts with round brackets
 # 2. there is no whitespace between the brackets and the content
 # e.g. " ( 'test string') " should be "('test string')"
 def trim_brackets(input_string:str):
-    # regex that matches either round bracket, 
+    # regex that matches either round bracket,
     # preceded or followed by whitespace
 
     # pattern = re.compile(r"(\(\s)|(\s\()|(\)\s)|(\s\))")
@@ -103,7 +102,7 @@ def trim_brackets(input_string:str):
 
     # while re.search(pattern, input_string) is not None:
     while re.search(pattern, input_string) is not None:
-        
+
         matched_groups = (g for g in re.search(pattern, input_string).groups() if g is not None)
 
         for group in matched_groups:
@@ -126,7 +125,7 @@ def remove_whitespace_between_quotes_between_brackets(input_string:str):
 
     if bracket_match is None:
         return input_string
-    
+
     bracket_contents = bracket_match.group(0)
 
     bracket_contents_cleaned = "(" + "".join(
@@ -144,14 +143,12 @@ def remove_whitespace_between_quotes_between_brackets(input_string:str):
     return result
 
 
-
 def collapse_lines(lines:List[str],delimiter = ""):
     buffer = []
     collapsed_lines = []
-    
 
     for line in lines:
-        # if the single line has both a closing and 
+        # if the single line has both a closing and
         # opening bracket, then it can be added straight away
         # because it cannot be further collapsed
         if "(" in line and ")" in line:
@@ -169,8 +166,7 @@ def collapse_lines(lines:List[str],delimiter = ""):
 
             # remove whitespace between quotes, between brackets
             collapsed_lines.append(delimiter.join(buffer))
-            buffer = ""
-
+            buffer = []
 
         # if the buffer has content in it, add current line
         elif len(buffer) > 0:
@@ -180,13 +176,11 @@ def collapse_lines(lines:List[str],delimiter = ""):
         else:
             collapsed_lines.append(line)
     return collapsed_lines
-    
+
 
 # TODO unit test
 # TODO refactor
-def find_soa_lines(text:str):
-
-    lines = text.splitlines()
+def find_soa_lines(lines):
 
     soa_start_line = 0
 
@@ -206,7 +200,6 @@ def find_soa_lines(text:str):
                 soa_end_line = soa_start_line
                 break
 
-
         if ")" in line and find_bracket is True:
             soa_end_line = line_number
             break
@@ -215,6 +208,7 @@ def find_soa_lines(text:str):
         return None
     else:
         return range(soa_start_line,soa_end_line + 1)
+
 
 # TODO unit test
 def parted_soa(text:str):

--- a/zonefile_parser/main.py
+++ b/zonefile_parser/main.py
@@ -36,17 +36,15 @@ def parse(text:str):
 
     # function to collapse records that are spread with brackets
     lines = collapse_lines(raw_lines)
-    
 
     ttl = default_ttl(text)
 
     origin = default_origin(text)
 
-    
     default_rclass = "IN"
 
     # find the SOA, process it, and add it back as a single line
-    soa_lines = find_soa_lines(text)
+    soa_lines = find_soa_lines(lines)
 
     if soa_lines is not None:
         raw_soa = "\n".join([lines[index] for index in soa_lines])
@@ -84,13 +82,13 @@ def parse(text:str):
         if record_line[0] == "@" and origin is not None:
             record_line = record_line.replace("@",origin)
             last_name = origin
-        # if the line behinds with a space, 
+        # if the line behinds with a space,
         # it inherits the name of the previously processed record
         elif record_line[0] == " ":
             record_line = last_name + record_line
         # if you specify a name, add the origin to the end of the name
         # provided that the name doesnt already have the origin
-        # 
+        #
         # $ORIGIN example.com
         # test              test.example.com
         # test.example.com  test.example.com
@@ -104,7 +102,6 @@ def parse(text:str):
         record_line = trim_brackets(record_line)
 
         normalized_records.append(record_line)
-
     normalized_records = list(
         map(
             shlex.split,
@@ -131,7 +128,6 @@ def parse(text:str):
             record.insert(2,default_rclass)
 
         return record
-
 
     normalized_records = list(
         map(


### PR DESCRIPTION
For a comparison of an AXFR export and a bind file, I made some modification (as already reported in #39): 
- buffer reinit in `collapse_lines` function point to an array instead of a string
- detect SOA field from parsed lines instead of raw text

