### PR TITLE
Remove print statement

### DIFF
--- a/zonefile_parser/helper.py
+++ b/zonefile_parser/helper.py
@@ -138,8 +138,6 @@ def remove_whitespace_between_quotes_between_brackets(input_string:str):
         input_string
     )
 
-    print(result)
-
     return result
 
 


### PR DESCRIPTION
I'm trying to build a CLI with this library, and this print statement is making for weird output.

It's not very nice for libraries to print stuff, they should instead use Python's logging library.