### PR TITLE
Support multiple origin

### DIFF
--- a/zonefile_parser/helper.py
+++ b/zonefile_parser/helper.py
@@ -78,13 +78,19 @@ def default_ttl(text:str):
     return None
 
 # TODO write test case
+def line_origin(line:str):
+    if "$ORIGIN".casefold() in line.casefold():
+        # delimiter exists ater the $ORIGIN
+        delimiter = line.casefold()[7]
+        origin = line.split(delimiter)[1]
+        return origin
+    return None
+
 def default_origin(text:str):
     lines = text.splitlines()
     for line in lines:
-        if "$ORIGIN".casefold() in line.casefold():
-            # delimiter exists ater the $ORIGIN
-            delimiter = line.casefold()[7]
-            origin = line.split(delimiter)[1]
+        origin = line_origin(line)
+        if origin:
             return origin
     return None
 

--- a/zonefile_parser/main.py
+++ b/zonefile_parser/main.py
@@ -1,7 +1,7 @@
 from zonefile_parser.helper import remove_comments
 from zonefile_parser.helper import remove_trailing_spaces
 from zonefile_parser.helper import default_ttl
-from zonefile_parser.helper import default_origin
+from zonefile_parser.helper import line_origin, default_origin
 from zonefile_parser.helper import find_soa_lines
 from zonefile_parser.helper import parted_soa
 from zonefile_parser.parser import parse_record
@@ -139,11 +139,11 @@ def parse(text:str):
 
         lines.insert(soa_lines[0]," ".join(soa_parts))
 
-    # remove all the $TTL & $ORIGIN lines, we have the values,
+    # remove all the $TTL lines, we have the values,
     # they are no longer needed.
     record_lines = list(
         filter(
-            lambda x : "$TTL".casefold() not in x.casefold() and "$ORIGIN".casefold() not in x.casefold(),
+            lambda x : "$TTL".casefold() not in x.casefold(),
             lines
         )
     )
@@ -158,6 +158,10 @@ def parse(text:str):
 
         # replace all tabs with spaces
         record_line = record_line.replace("\t"," ")
+
+        origin_of_line = line_origin(record_line)
+        if origin_of_line:
+            origin = origin_of_line
 
         name = record_line[:record_line.index(" ")]
 
@@ -176,7 +180,9 @@ def parse(text:str):
         # test              test.example.com
         # test.example.com  test.example.com
         elif origin is not None and not name.endswith(origin):
-            record_line = record_line.replace(name,name + "." + origin)
+            old_name, name = name, name + "." + origin
+            record_line = record_line.replace(old_name,name)
+            last_name = name
         else:
             last_name = name
 


### PR DESCRIPTION
Some files have this kind of content:

```
$ORIGIN .
$TTL 10 ; 10 seconds
main.tld.            IN SOA  ns0.main.tld. hostmaster.main.tld. (
                753318     ; serial
                10800      ; refresh (3 hours)
                3600       ; retry (1 hour)
                604800     ; expire (1 week)
                10         ; minimum (10 seconds)
                )
$TTL 3600   ; 1 hour
            NS  ns0.main.tld.
            NS  ns1.main.tld.
$ORIGIN main.tld.
00          A   x.x.x.x
            MX  10 00
            TXT "v=spf1 a mx -all"
            CAA 0 issue "letsencrypt.org"
$ORIGIN 00.main.tld.
*           A   x.x.x.x
_dmarc          TXT "v=DMARC1; p=none"
$ORIGIN main.tld.
01        MX  10 01
            TXT "v=spf1 a mx -all"
            CAA 128 issue "letsencrypt.org"
$ORIGIN 01.main.tld.
*           A   89.234.140.181
            AAAA    2a00:5881:4008:7500::42
_dmarc          TXT "v=DMARC1; p=none"
```

We need to handle these multiple `$ORIGIN` lines.

