### PR TITLE
Fix ValueError when parsing TXT records with escaped semicolons (\;)

### DIFF
--- a/zonefile_parser/helper.py
+++ b/zonefile_parser/helper.py
@@ -3,6 +3,8 @@ from typing import List
 def remove_comments(line:str):
     for index,character in enumerate(line):
         if character == ";" and not is_in_quote(line,index):
+            if index > 0 and line[index - 1] == '\\':
+                continue
             line = line[:index]
             break
     return line

--- a/zonefile_parser/helper_test.py
+++ b/zonefile_parser/helper_test.py
@@ -16,6 +16,16 @@ class TestRemoveComments:
         result = helper.remove_comments(input)
         assert result == input
 
+    def test_doesnt_remove_escaped_semicolon(self):
+        input = r"v=DMARC1\;"
+        result = helper.remove_comments(input)
+        assert result == input
+
+    def test_removes_comment_after_escaped_semicolon(self):
+        input = r"v=DMARC1\; comment"
+        result = helper.remove_comments(input)
+        assert result == input
+
 class TestIsInQuote:
     def test_returns_whether_index_in_quote(self):
         input = '"A"'

--- a/zonefile_parser/helper_test.py
+++ b/zonefile_parser/helper_test.py
@@ -21,7 +21,7 @@ class TestRemoveComments:
         result = helper.remove_comments(input)
         assert result == input
 
-    def test_removes_comment_after_escaped_semicolon(self):
+    def test_doesnt_treat_text_after_escaped_semicolon_as_comment(self):
         input = r"v=DMARC1\; comment"
         result = helper.remove_comments(input)
         assert result == input

--- a/zonefile_parser/main_test.py
+++ b/zonefile_parser/main_test.py
@@ -343,6 +343,22 @@ _dmarc 3600 IN TXT v=DMARC1\\;
         assert record.rtype == "TXT"
         assert record.rdata == {"value": "v=DMARC1;"}
 
+    def test_issue_49_dmarc_record_with_comment(self):
+        # DMARC TXT record with escaped semicolons and a trailing comment
+        # the comment (after unescaped ;) should be stripped, \; should survive as ;
+        text = """
+$TTL 3600
+$ORIGIN example.com.
+_dmarc 3600 IN TXT v=DMARC1\\; p=none\\; rua=mailto:dmarc@example.com ; this is a comment
+"""
+        result = zonefile_parser.main.parse(text)
+
+        record = result[0]
+
+        assert record.name == "_dmarc.example.com."
+        assert record.rtype == "TXT"
+        assert record.rdata == {"value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com"}
+
     def test_multiple_cnames_with_name_in_target(self):
         # multiple records in the same zone, each with name appearing in their CNAME target
         text = """

--- a/zonefile_parser/main_test.py
+++ b/zonefile_parser/main_test.py
@@ -344,12 +344,12 @@ _dmarc 3600 IN TXT v=DMARC1\\;
         assert record.rdata == {"value": "v=DMARC1;"}
 
     def test_issue_49_dmarc_record_with_comment(self):
-        # DMARC TXT record with escaped semicolons and a trailing comment
-        # the comment (after unescaped ;) should be stripped, \; should survive as ;
+        # DMARC TXT record with an escaped semicolon followed by a real comment
+        # the real comment (unescaped ;) should be stripped, \; should survive as ;
         text = """
 $TTL 3600
 $ORIGIN example.com.
-_dmarc 3600 IN TXT v=DMARC1\\; p=none\\; rua=mailto:dmarc@example.com ; this is a comment
+_dmarc 3600 IN TXT v=DMARC1\\; ; this is a comment
 """
         result = zonefile_parser.main.parse(text)
 
@@ -357,7 +357,7 @@ _dmarc 3600 IN TXT v=DMARC1\\; p=none\\; rua=mailto:dmarc@example.com ; this is 
 
         assert record.name == "_dmarc.example.com."
         assert record.rtype == "TXT"
-        assert record.rdata == {"value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com"}
+        assert record.rdata == {"value": "v=DMARC1;"}
 
     def test_multiple_cnames_with_name_in_target(self):
         # multiple records in the same zone, each with name appearing in their CNAME target

--- a/zonefile_parser/main_test.py
+++ b/zonefile_parser/main_test.py
@@ -328,6 +328,21 @@ mail 3600 IN TXT "v=spf1 include:mail.otherdomain.com ~all"
         assert record.rtype == "TXT"
         assert record.rdata == {"value": "v=spf1 include:mail.otherdomain.com ~all"}
 
+    def test_issue_49_escaped_semicolon_in_txt(self):
+        # TXT record with a trailing escaped semicolon (\;) should not raise ValueError
+        text = """
+$TTL 3600
+$ORIGIN example.com.
+_dmarc 3600 IN TXT v=DMARC1\\;
+"""
+        result = zonefile_parser.main.parse(text)
+
+        record = result[0]
+
+        assert record.name == "_dmarc.example.com."
+        assert record.rtype == "TXT"
+        assert record.rdata == {"value": "v=DMARC1;"}
+
     def test_multiple_cnames_with_name_in_target(self):
         # multiple records in the same zone, each with name appearing in their CNAME target
         text = """


### PR DESCRIPTION
The remove_comments function was treating \; as a comment boundary, stripping the semicolon and leaving a trailing backslash. This caused shlex.split to raise ValueError: No escaped character.

Now escaped semicolons are skipped so they are preserved as part of the record value, which shlex correctly converts to a literal semicolon.

Fixes #49
