### PR TITLE
Fix __repr__ returning dict instead of str in Record class

### DIFF
--- a/zonefile_parser/main_test.py
+++ b/zonefile_parser/main_test.py
@@ -343,3 +343,16 @@ www 3600 IN CNAME www.cdn.net.
 
         assert result[1].name == "www.example.com."
         assert result[1].rdata == {"value": "www.cdn.net."}
+
+    def test_issue_44_print_records_does_not_raise(self):
+        text = """
+$TTL 3600
+$ORIGIN example.com.
+@ 3600 IN A 192.0.2.1
+"""
+        records = zonefile_parser.main.parse(text)
+        # __repr__ must return a str; printing a list calls repr() on each element
+        assert isinstance(repr(records[0]), str)
+        # str(record) and print(records) must not raise
+        assert isinstance(str(records[0]), str)
+        _ = str(records)  # exercises list __repr__, which calls record.__repr__()

--- a/zonefile_parser/record.py
+++ b/zonefile_parser/record.py
@@ -25,13 +25,13 @@ class Record:
         return str(self.__repr__())
 
     def __repr__(self):
-        return {
+        return str({
             "rtype":self.rtype,
             "name":self.name,
             "rclass":self.rclass,
             "rdata":self.rdata ,
             "ttl":self.ttl
-        }
+        })
 
     def validate(self):
         # TODO make this work


### PR DESCRIPTION
__repr__ must return a str, but it was returning a dict, causing a TypeError when printing records. Wrap the dict in str() to fix.

Fixes #44